### PR TITLE
- Added: Command `tit use` 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -239,3 +239,5 @@ fabric.properties
 .idea/caches/build_file_checksums.ser
 
 /.idea/misc.xml
+
+/.tit/

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 import typer
 from tit import __version__
-from tit.commands import tit_init
+from tit.commands import tit_init, tit_use
 
 # Create a Typer app instance.
 # Set the app's help message with the version information.
@@ -34,6 +34,7 @@ def get_version(
 # -----------------Commands----------------------
 
 app.add_typer(tit_init.app, name="init")
+app.add_typer(tit_use.app, name="use")
 
 # Execute the Typer app when the script is run directly
 if __name__ == "__main__":

--- a/poetry.lock
+++ b/poetry.lock
@@ -197,6 +197,65 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.1"
+description = "YAML parser and emitter for Python"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "PyYAML-6.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a"},
+    {file = "PyYAML-6.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"},
+    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
+    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
+    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
+    {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
+    {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
+    {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
+    {file = "PyYAML-6.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab"},
+    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
+    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
+    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
+    {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
+    {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
+    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:afd7e57eddb1a54f0f1a974bc4391af8bcce0b444685d936840f125cf046d5bd"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-win32.whl", hash = "sha256:fca0e3a251908a499833aa292323f32437106001d436eca0e6e7833256674585"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:f22ac1c3cac4dbc50079e965eba2c1058622631e526bd9afd45fedd49ba781fa"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b1275ad35a5d18c62a7220633c913e1b42d44b46ee12554e5fd39c70a243d6a3"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:18aeb1bf9a78867dc38b259769503436b7c72f7a1f1f4c93ff9a17de54319b27"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:596106435fa6ad000c2991a98fa58eeb8656ef2325d7e158344fb33864ed87e3"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:baa90d3f661d43131ca170712d903e6295d1f7a0f595074f151c0aed377c9b9c"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-win32.whl", hash = "sha256:9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:4fb147e7a67ef577a588a0e2c17b6db51dda102c71de36f8549b6816a96e1867"},
+    {file = "PyYAML-6.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1d4c7e777c441b20e32f52bd377e0c409713e8bb1386e1099c2415f26e479595"},
+    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
+    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
+    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
+    {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
+    {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
+    {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
+    {file = "PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859"},
+    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
+    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
+    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
+    {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
+    {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
+]
+
+[[package]]
 name = "rich"
 version = "13.5.2"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
@@ -271,4 +330,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "3eb7044b5f4358cba26ceba49c4fccbb2b70bb1bdb8265345dcf30fbf9ba6bb9"
+content-hash = "a6ceb0489e2b62f41877db9935d3132d3285ffa29e338b3c9fc21bbdd2ccce64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ rich = "^13.5.2"
 shellingham = "^1.5.2"
 pytest = "^7.4.0"
 flake8 = "^6.1.0"
+pyyaml = "^6.0.1"
 
 
 [build-system]

--- a/tests/test_check_repo.py
+++ b/tests/test_check_repo.py
@@ -1,0 +1,89 @@
+import os
+import tempfile
+import datetime
+import yaml
+from tit.check_repo import current_datetime, check_if_repo
+
+
+def test_current_datetime():
+    # Test if current_datetime() returns the expected formatted datetime
+    expected_format = '%Y-%m-%d %H:%M:%S'
+    current_time = datetime.datetime.now()
+    formatted_current = current_time.strftime(expected_format)
+    assert current_datetime() == formatted_current
+
+
+def test_check_if_repo_no_repo():
+    # Test when no repo exists
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        assert not check_if_repo()
+
+
+def test_check_if_repo_git_repo():
+    # Test when a .git repo exists
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        os.mkdir(".git")
+        assert check_if_repo()
+
+
+def test_check_if_repo_tit_repo():
+    # Test when a .tit repo exists
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        os.mkdir(".tit")
+        assert check_if_repo()
+
+
+def test_check_if_repo_git_repo_with_invalid_tit_config():
+    # Test when a .git repo exists with an invalid tit_config.yaml
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        os.mkdir(".git")
+        with open(os.path.join('.git', 'tit_config.yaml'), 'w') as file:
+            file.write("invalid_yaml: basinful")
+        assert not check_if_repo()
+
+
+def test_check_if_repo_git_repo_with_valid_tit_config():
+    # Test when a .git repo exists with a valid tit_config.yaml
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        os.mkdir(".git")
+        with open(os.path.join('.git', 'tit_config.yaml'), 'w') as file:
+            yaml_data = {'Repo_type': '.git'}
+            yaml.dump(yaml_data, file)
+        assert check_if_repo()
+
+
+def test_check_if_repo_git_repo_with_valid_tit_config_wrong_type():
+    # Test when a .git repo exists with a valid but wrong tit_config.yaml
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        os.mkdir(".git")
+        with open(os.path.join('.git', 'tit_config.yaml'), 'w') as file:
+            yaml_data = {'Repo_type': 'invalid'}
+            yaml.dump(yaml_data, file)
+        assert not check_if_repo()
+
+
+def test_check_if_repo_mixed_case():
+    # Test when both .git and .tit repos exist
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        os.mkdir(".git")
+        os.mkdir(".tit")
+        assert check_if_repo()
+
+
+def test_check_if_repo_verbose(capsys):
+    # Test verbose mode for check_if_repo()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        os.mkdir(".tit")
+        check_if_repo(verbose=True)
+        captured = capsys.readouterr()
+        assert "tit repo found in" in captured.out  # Check if print was called
+
+# Add more test cases as needed

--- a/tests/test_check_repo.py
+++ b/tests/test_check_repo.py
@@ -3,6 +3,7 @@ import tempfile
 import datetime
 import yaml
 from tit.check_repo import current_datetime, check_if_repo
+from tit.write_file import write_file
 
 
 def test_current_datetime():
@@ -18,14 +19,6 @@ def test_check_if_repo_no_repo():
     with tempfile.TemporaryDirectory() as tmpdir:
         os.chdir(tmpdir)
         assert not check_if_repo()
-
-
-def test_check_if_repo_git_repo():
-    # Test when a .git repo exists
-    with tempfile.TemporaryDirectory() as tmpdir:
-        os.chdir(tmpdir)
-        os.mkdir(".git")
-        assert check_if_repo()
 
 
 def test_check_if_repo_tit_repo():
@@ -51,9 +44,7 @@ def test_check_if_repo_git_repo_with_valid_tit_config():
     with tempfile.TemporaryDirectory() as tmpdir:
         os.chdir(tmpdir)
         os.mkdir(".git")
-        with open(os.path.join('.git', 'tit_config.yaml'), 'w') as file:
-            yaml_data = {'Repo_type': '.git'}
-            yaml.dump(yaml_data, file)
+        write_file(".git/tit_config.yaml", 'Repo_type: ".git"')
         assert check_if_repo()
 
 

--- a/tests/test_tit_init.py
+++ b/tests/test_tit_init.py
@@ -1,57 +1,77 @@
 from typer.testing import CliRunner
 from main import app
+import tempfile
 import os
+
 
 runner = CliRunner()
 
 
-def test_tit_init_existing_git():
-    # Create a temporary .git directory for testing
-    with runner.isolated_filesystem():
-        os.mkdir(".git")  # Create a .git directory
+def test_tit_init():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        # Test tit init without force or verbose
         result = runner.invoke(app, ["init"])
-        assert result.exit_code == 0
-        assert "This seems to be a git repository." in result.output
+        assert "Initialized an empty tit repository" in result.output
 
 
-def test_tit_init_existing_git_force():
-    # Create a temporary .git directory for testing
-    with runner.isolated_filesystem():
-        os.mkdir(".git")  # Create a .git directory
+def test_tit_init_force():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        os.mkdir('.git')
+        # Test tit init with force option
         result = runner.invoke(app, ["init", "--force"])
-        assert result.exit_code == 0
         assert "Initialized an empty tit repository" in result.output
 
 
-def test_tit_init_not_git_repo():
-    with runner.isolated_filesystem():
-        result = runner.invoke(app, ["init"])
-        assert result.exit_code == 0
-        assert "Initialized an empty tit repository" in result.output
-
-
-def test_tit_init_force_not_git_repo():
-    with runner.isolated_filesystem():
-        result = runner.invoke(app, ["init", "--force"])
-        assert result.exit_code == 0
-        assert "Initialized an empty tit repository" in result.output
-
-
-def test_tit_init_existing_tit_repo():
-    # Create a temporary .tit directory for testing
-    with runner.isolated_filesystem():
-        os.mkdir(".tit")  # Create a .tit directory
-        result = runner.invoke(app, ["init"])
-        assert result.exit_code == 0
-        assert "a tit repo already exist." in result.output
-
-
-def test_tit_init_verbose_existing_tit_repo():
-    # Create a temporary .tit directory for testing
-    with runner.isolated_filesystem():
-        os.mkdir(".tit")  # Create a .tit directory
+def test_tit_init_verbose():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        # Test tit init with verbose option
         result = runner.invoke(app, ["init", "--verbose"])
+        assert "Initialized an empty tit repository" in result.output
+
+
+def test_tit_init_existing_repo():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        os.mkdir(".tit")
+        # Test tit init when a .tit repo already exists
+        result = runner.invoke(app, ["init"])
         assert result.exit_code == 0
+
+
+def test_tit_init_existing_repo_force():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        os.mkdir('.tit')
+        # Test tit init when a .tit repo already exists with force option
+        result = runner.invoke(app, ["init", "--force"])
         assert "a tit repo already exist." in result.output
 
-# Add more test cases as needed
+
+def test_tit_init_existing_git_repo():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        os.mkdir('.git')
+        # Test tit init when a .git repo already exists
+        result = runner.invoke(app, ["init"])
+        assert "This seems to be a git repository" in result.output
+
+
+def test_tit_init_existing_git_repo_force():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        os.mkdir('.git')
+        # Test tit init when a .git repo already exists with force option
+        result = runner.invoke(app, ["init", "--force"])
+        assert "Initialized an empty tit repository" in result.output
+
+
+def test_tit_init_existing_git_repo_verbose():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        os.mkdir('.git')
+        # Test tit init when a .git repo already exists with verbose option
+        result = runner.invoke(app, ["init", "--verbose"])
+        assert "This seems to be a git repository" in result.output

--- a/tests/test_tit_use.py
+++ b/tests/test_tit_use.py
@@ -1,0 +1,34 @@
+from typer.testing import CliRunner
+from main import app
+import tempfile
+import os
+
+runner = CliRunner()
+
+
+def test_tit_use_valid_vcs():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        os.mkdir(".git")
+
+        # Capture the printed output
+        result = runner.invoke(app, ["use", "git"])
+        # Assert exit code
+        assert result.exit_code == 0
+
+
+def test_tit_use_invalid_vcs():
+    result = runner.invoke(app, ["use", "svn"])
+    assert result.exit_code == 0
+    assert "INVALID: svn VCS not supported." in result.output
+
+
+def test_tit_use_already_set_up():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        os.mkdir(".git")
+        with open(".git/tit_config.yaml", "w+") as file:
+            file.write("Repo_type: \".git\"")
+        result = runner.invoke(app, ["use", "git"])
+        assert result.exit_code == 0
+        assert "Already set up to use git repo" in result.output

--- a/tests/test_write_file.py
+++ b/tests/test_write_file.py
@@ -1,0 +1,46 @@
+import os
+import tempfile
+from tit.write_file import write_binary_file, read_tit_config_yaml_file, write_file
+
+
+def test_write_binary_file():
+    # Create a temporary file for testing
+    with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
+        tmp_file_path = tmp_file.name
+        data = b"Hello, world!"
+        write_binary_file(tmp_file_path, data)
+
+    with open(tmp_file_path, "rb") as tmp_file_read:
+        assert tmp_file_read.read() == data
+
+    os.remove(tmp_file_path)
+
+
+def test_read_tit_config_yaml_file():
+    # Create a temporary file for testing
+    with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
+        tmp_file_path = tmp_file.name
+        repo_type = 'Repo_type: ".git"'
+        tmp_file.write(repo_type.encode())
+        tmp_file.close()
+
+        assert read_tit_config_yaml_file(tmp_file_path)
+        os.remove(tmp_file_path)
+
+    # Test case when file doesn't exist
+    assert not read_tit_config_yaml_file("nonexistent.yaml")
+
+
+def test_write_file():
+    # Create a temporary file for testing
+    with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
+        tmp_file_path = tmp_file.name
+        data = "Hello, world!"
+        write_file(tmp_file_path, data)
+
+    with open(tmp_file_path, "r") as tmp_file_read:
+        assert tmp_file_read.read() == data
+
+    os.remove(tmp_file_path)
+
+# Run the tests using the pytest command

--- a/tit/check_repo.py
+++ b/tit/check_repo.py
@@ -1,0 +1,66 @@
+# authors: ["Prakash4844 <pk484442@gmail.com>"]
+# command: N/A
+# date: 31 Aug, 2023
+
+import os
+import datetime
+import yaml
+from rich import print
+
+
+def current_datetime():
+    """
+    :return: current datetime
+    """
+    current = datetime.datetime.now()
+    formatted_current = current.strftime('%Y-%m-%d %H:%M:%S')
+    return formatted_current
+
+
+def print_info(verbose: bool = False):
+    print("This seems to be a git repository, but is not set up to be used with tit.")
+    print("Use [bold green]tit use[/bold green] command to set up tit to use already available git "
+          "repo.")
+    print("Use optional [blue][-f | --force][/blue] options to create a tit repo.\n\n")
+    if verbose:
+        print("example 1: [bold green]tit init[/bold green] [blue][-f | --force][/blue]\nOR")
+        print("example 2: [bold green]tit use git[/bold green]")
+
+
+def check_if_repo(verbose: bool = False) -> bool:
+    """
+    check if a .git repo already exist in current working directory
+    :param verbose: enables verbose logging
+    :return:
+    """
+    if verbose:
+        print(f"{current_datetime()}: checking if a git repository already exist in {os.getcwd()}")
+
+    if os.path.isdir(".tit"):  # if already a tit repo
+        if verbose:
+            print(f'tit repo found in {os.getcwd()}')
+        return True
+    else:
+        if os.path.isdir(".git"):  # if already a git repo
+            try:
+                if os.path.isfile('.git/tit_config.yaml'):
+                    with open(os.path.join('.git/tit_config.yaml')) as file:
+                        tit_config = yaml.safe_load(file)
+                        tit_config = dict(tit_config)
+                        if tit_config.get('Repo_type') == '.git':
+                            print("repo already set up.")
+                            return True
+                        else:
+                            return False
+                else:
+                    print_info(verbose)
+                    return True
+            except (FileNotFoundError, yaml.YAMLError):
+                if yaml.YAMLError:
+                    print("[bold red]Error:[/bold red] Invalid YAML")
+                    return True
+                print_info(verbose)
+                return True
+        else:
+            print(f'[bold red]Error:[/bold red] Neither git nor a tit repo found in {os.getcwd()}')
+            return False

--- a/tit/check_repo.py
+++ b/tit/check_repo.py
@@ -10,7 +10,8 @@ from rich import print
 
 def current_datetime():
     """
-    :return: current datetime
+    Get the current datetime in a formatted string.
+    :return: Formatted current datetime string.
     """
     current = datetime.datetime.now()
     formatted_current = current.strftime('%Y-%m-%d %H:%M:%S')
@@ -18,49 +19,68 @@ def current_datetime():
 
 
 def print_info(verbose: bool = False):
+    """
+    Print information about setting up tit repository.
+    :param: verbose: If True, print verbose instructions.
+    """
     print("This seems to be a git repository, but is not set up to be used with tit.")
     print("Use [bold green]tit use[/bold green] command to set up tit to use already available git "
-          "repo.")
-    print("Use optional [blue][-f | --force][/blue] options to create a tit repo.\n\n")
+          "repo. \n\t\t\tOR")
+    print("Use optional [blue][-f | --force][/blue] options to create a tit repo.\n")
     if verbose:
-        print("example 1: [bold green]tit init[/bold green] [blue][-f | --force][/blue]\nOR")
+        print("example 1: [bold green]tit init[/bold green] [blue][-f | --force][/blue]\n\t\tOR")
         print("example 2: [bold green]tit use git[/bold green]")
+
+
+def check_tit_config(verbose: bool = False) -> bool:
+    """
+    check if the git repo is set up to be used with tit.
+    :param verbose: If True, print verbose information.
+    :return: bool
+    """
+    try:
+        if os.path.isfile('.git/tit_config.yaml'):
+            with open(os.path.join('.git/tit_config.yaml')) as file:
+                tit_config = yaml.safe_load(file)
+                tit_config = dict(tit_config)
+                if tit_config.get('Repo_type') == '.git':
+                    print("tit is set up to work with already present git repo.")
+                    return True
+                else:
+                    return False
+        else:
+            print_info(verbose)
+            return True
+    except (FileNotFoundError, yaml.YAMLError):
+        if yaml.YAMLError:
+            print("[bold red]Error:[/bold red] Invalid YAML")
+            return True
+        print_info(verbose)
+        return True
 
 
 def check_if_repo(verbose: bool = False) -> bool:
     """
     check if a .git repo already exist in current working directory
-    :param verbose: enables verbose logging
-    :return:
+    Print information about setting up tit repository.
+    :param verbose: If True, print verbose  information.
+    :returns: bool
     """
-    if verbose:
-        print(f"{current_datetime()}: checking if a git repository already exist in {os.getcwd()}")
 
-    if os.path.isdir(".tit"):  # if already a tit repo
-        if verbose:
-            print(f'tit repo found in {os.getcwd()}')
-        return True
-    else:
-        if os.path.isdir(".git"):  # if already a git repo
-            try:
-                if os.path.isfile('.git/tit_config.yaml'):
-                    with open(os.path.join('.git/tit_config.yaml')) as file:
-                        tit_config = yaml.safe_load(file)
-                        tit_config = dict(tit_config)
-                        if tit_config.get('Repo_type') == '.git':
-                            print("repo already set up.")
-                            return True
-                        else:
-                            return False
-                else:
-                    print_info(verbose)
-                    return True
-            except (FileNotFoundError, yaml.YAMLError):
-                if yaml.YAMLError:
-                    print("[bold red]Error:[/bold red] Invalid YAML")
-                    return True
-                print_info(verbose)
-                return True
-        else:
-            print(f'[bold red]Error:[/bold red] Neither git nor a tit repo found in {os.getcwd()}')
-            return False
+    if verbose:
+        print(f"{current_datetime()}: checking if a git repository already exist in current or any of the parent "
+              f"directories")
+
+    current_dir = os.getcwd()  # Get the current working directory
+    while current_dir != "/":  # Stop when reaching the root directory
+        if os.path.isdir('.tit'):
+            print(f'A tit repo found in {os.getcwd()}')
+            return True
+        elif os.path.isdir('.git'):
+            print(f'A git repo found in {os.getcwd()}')
+            is_config = check_tit_config(verbose)
+            return is_config
+        current_dir = os.path.dirname(current_dir)  # Move to the parent directory
+    print('[bold red]Error:[/bold red] Neither git nor a tit repo found in Current of any of the parent '
+          'directories.')
+    return False

--- a/tit/commands/tit_init.py
+++ b/tit/commands/tit_init.py
@@ -3,50 +3,18 @@
 # date: 20 Aug, 2023
 
 import os
-import datetime
 import typer
+from rich import print
 from typer import Typer
 from typing_extensions import Annotated
-
-
-def current_datetime():
-    """
-    :return: current datetime
-    """
-    return datetime.datetime.now()
-
+from tit.write_file import write_binary_file
+from tit.check_repo import current_datetime, check_if_repo
 
 # create a typer app using required data.
 app = Typer(
     help="tit init: Create an empty Tit repository or reinitialize an existing one",
     context_settings={"help_option_names": ["-h", "--help"]}
 )
-
-
-def check_if_git_repo(verbose: bool = False) -> bool:
-    """
-    check if a .git repo already exist in current working directory
-    :param verbose: enables verbose logging
-    :return:
-    """
-    if os.path.isdir(".git"):  # if already a git repo
-        if verbose:
-            print(f"{current_datetime()}: checking if a git repository already exist in {os.getcwd()}")
-        print("This seems to be a git repository.")
-        print("Use optional [-f | --force] options to create a tit repo")
-        if verbose:
-            print("example: tit init --force")
-        return True
-    else:
-        return False
-
-
-def write_file(path, data):
-    """
-    Write data bytes to file at given path.
-    """
-    with open(path, 'wb') as f:
-        f.write(data)
 
 
 def create_repo(verbose: bool = False) -> None:
@@ -56,14 +24,14 @@ def create_repo(verbose: bool = False) -> None:
     :return:
     """
     if verbose:
-        print(f"{current_datetime()}: making a empty tit repository in {os.getcwd()}")
+        print(f"[green]{current_datetime()}[/green]: making a empty tit repository in [blue]{os.getcwd()}[blue]")
     try:
         os.mkdir(os.path.join('.tit'))
         for name in ['objects', 'refs', 'refs/heads']:
             os.mkdir(os.path.join('.tit', name))
-        write_file(os.path.join('.tit', 'HEAD'),
-                   b'ref: refs/heads/main')
-        print("Initialized an empty tit repository")
+        write_binary_file(os.path.join('.tit', 'HEAD'),
+                          b'ref: refs/heads/main')
+        print(f"Initialized an empty tit repository in [blue]{os.getcwd()}[blue]")
     except FileExistsError:
         print("a tit repo already exist.")
 
@@ -87,6 +55,7 @@ def tit_init(
     :param: verbose: enables verbose logging
     :return:
     """
+
     if force and not verbose:
         create_repo()
         exit(0)
@@ -94,15 +63,15 @@ def tit_init(
         create_repo(verbose=verbose)
         exit()
 
-    is_git_repo = check_if_git_repo(verbose=verbose)
+    is_git_repo = check_if_repo(verbose=verbose)
 
-    if is_git_repo:
-        exit(0)
-    else:
+    if not is_git_repo:
         if verbose:
             create_repo(verbose=verbose)
         else:
             create_repo()
+    else:
+        exit(0)
 
 
 if __name__ == "__main__":

--- a/tit/commands/tit_use.py
+++ b/tit/commands/tit_use.py
@@ -27,7 +27,6 @@ def tit_use(vcs: str) -> None:
             try:
                 write_file(".git/tit_config.yaml", 'Repo_type: ".git"')
                 print("[green]Set up:[/green] tit to use .git repository")
-                print("Set up: tit to use .git repository")
             except NotADirectoryError:
                 print("[bold red]FATAL:[/bold red] No git repo found.")
     else:

--- a/tit/commands/tit_use.py
+++ b/tit/commands/tit_use.py
@@ -1,0 +1,38 @@
+# authors: ["Prakash4844 <pk484442@gmail.com>"]
+# command: tit use
+# date: 30 Aug, 2023
+
+from typer import Typer
+from rich import print
+from tit.write_file import write_file, read_tit_config_yaml_file
+
+# create a typer app using required data.
+app = Typer(
+    help="tit use: Set tit to use a repository that is not of type TIT (eg: git)",
+    context_settings={"help_option_names": ["-h", "--help"]}
+)
+
+
+@app.callback(invoke_without_command=True)
+def tit_use(vcs: str) -> None:
+    """
+    tit use: Set tit to use a repository that is not of type TIT (eg: .git)
+    :param: vcs (VCS Repo Type (eg: git)
+    :return:
+    """
+    if vcs.lower() == "git":
+        if read_tit_config_yaml_file(".git/tit_config.yaml"):
+            print("Already set up to use git repo")
+        else:
+            try:
+                write_file(".git/tit_config.yaml", 'Repo_type: ".git"')
+                print("[green]Set up:[/green] tit to use .git repository")
+                print("Set up: tit to use .git repository")
+            except NotADirectoryError:
+                print("[bold red]FATAL:[/bold red] No git repo found.")
+    else:
+        print(f"[bold red]INVALID:[/bold red] {vcs} VCS not supported.")
+
+
+if __name__ == "__main__":
+    app()

--- a/tit/write_file.py
+++ b/tit/write_file.py
@@ -16,6 +16,9 @@ def read_tit_config_yaml_file(path):
             repo_name = f.readline()
             if repo_name == 'Repo_type: ".git"':
                 return True
+            elif repo_name != 'Repo_type: ".git"':
+                print("tit config file found, but doesn't contain any supported VCS")
+                return False
     except FileNotFoundError:
         return False
 

--- a/tit/write_file.py
+++ b/tit/write_file.py
@@ -1,0 +1,28 @@
+# authors: ["Prakash4844 <pk484442@gmail.com>"]
+# command: N/A
+# date: 31 Aug, 2023
+
+def write_binary_file(path, data):
+    """
+    Write data bytes to file at given path.
+    """
+    with open(path, 'wb') as f:
+        f.write(data)
+
+
+def read_tit_config_yaml_file(path):
+    try:
+        with open(path) as f:
+            repo_name = f.readline()
+            if repo_name == 'Repo_type: ".git"':
+                return True
+    except FileNotFoundError:
+        return False
+
+
+def write_file(path, data):
+    """
+        Write text to file at given path.
+    """
+    with open(path, 'w+') as f:
+        f.write(data)


### PR DESCRIPTION
so we can set up tit to use already available .git repo

- Added: dependency PyYAML

- restructured `tit init` command and separated code for checking Repo and R/W files

- Use Rich Print function to format the prints

- Updated and Added Test Cases.

- Now we check for repo in current and all the parent folder till root directory

- Updated gitignore to ignore .tit files for the time being

- Updated and improved code for init and use